### PR TITLE
switched to babel-plugin-istanbul

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,18 +1,25 @@
 {
-  "presets": [
-    "es2015"
-  ],
-  "sourceMaps": "inline",
-  "env": {
-    "lines": {
-      "retainLines": true,
-    },
-    "plugin": {
-      "plugins": ["babel-plugin-rewire"]
-    },
-    "linesplugin": {
-      "retainLines": true,
-      "plugins": ["babel-plugin-rewire"]
-    },
-  }
+	"presets": [
+		"es2015"
+	],
+	"sourceMaps": "inline",
+	"env": {
+		"lines": {
+			"retainLines": true,
+		},
+		"plugin": {
+			"plugins": {
+				"babel-plugin-istanbul": {
+					"include": [ "index.js" ],
+					"exclude": [ "test.js" ]
+				}, 
+				"babel-plugin-rewire": {
+				} 
+			}
+		},
+		"linesplugin": {
+			"retainLines": true,
+			"plugins": ["babel-plugin-rewire"]
+		},
+	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "private": true,
   "config": {
     "nyc": {
+      "sourceMap": false,
+      "instrument": false,
       "require": [
         "babel-register"
       ]
@@ -22,9 +24,12 @@
     "babel-register": "^6.3.13",
     "chai": "^3.4.0",
     "mocha": "^2.3.4",
-    "nyc": "^5.5.0"
+    "nyc": "^7.1.0"
   },
   "engines": {
     "node": ">= 0.12.0"
+  },
+  "devDependencies": {
+    "babel-plugin-istanbul": "^2.0.1"
   }
 }


### PR DESCRIPTION
switched the sample to babel-plugin-istanbul to ensure that 100% code coverage can be achieved.
This should fix https://github.com/speedskater/babel-plugin-rewire/issues/95
